### PR TITLE
Update pybind11 usage for sub plugin classes

### DIFF
--- a/torch2trt/plugins/plugins.cpp
+++ b/torch2trt/plugins/plugins.cpp
@@ -7,7 +7,7 @@ using namespace nvinfer1;
 
 namespace torch2trt {
     PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
-        py::class_<InterpolatePlugin>(m, "InterpolatePlugin")
+        py::class_<InterpolatePlugin, IPluginV2>(m, "InterpolatePlugin")
             .def(py::init<std::vector<int64_t>, std::string, bool>(), py::arg("size"), py::arg("mode"), py::arg("align_corners"))
             .def(py::init<const std::string &>(), py::arg("data"))
             .def("getSerializationSize", &InterpolatePlugin::getSerializationSize)
@@ -16,7 +16,7 @@ namespace torch2trt {
                     std::string data = plugin.serializeToString();
                     return py::bytes(data);
                     });
-        py::class_<GroupNormPlugin>(m, "GroupNormPlugin")
+        py::class_<GroupNormPlugin, IPluginV2>(m, "GroupNormPlugin")
             .def(py::init<int64_t, at::Tensor, at::Tensor, double>(), py::arg("num_groups"), py::arg("weight"), py::arg("bias"), py::arg("eps"))
             .def(py::init<const std::string &>(), py::arg("data"))
             .def("getSerializationSize", &GroupNormPlugin::getSerializationSize)


### PR DESCRIPTION
the following test would be failed in some cases:
```python
python3 -m torch2trt.test --name=group  
```
```

TypeError: add_plugin_v2(): incompatible function arguments. The following argument types are supported:
    1. (self: tensorrt.tensorrt.INetworkDefinition, inputs: List[tensorrt.tensorrt.ITensor], plugin: tensorrt.tensorrt.IPluginV2) -> tensorrt.tensorrt.IPluginV2Layer

Invoked with: <tensorrt.tensorrt.INetworkDefinition object at 0x7f270e6e2a40>, [<tensorrt.tensorrt.ITensor object at 0x7f2726321d18>], <torch2trt.plugins.GroupNormPlugin object at 0x7f2726321f80>
```
see 

#https://github.com/NVIDIA-AI-IOT/torch2trt/pull/656#issuecomment-1010937335

This PR  try to fix this issue.